### PR TITLE
chore: refresh GOAT explorer logo config URLs

### DIFF
--- a/docker-compose/envs/common-frontend.env
+++ b/docker-compose/envs/common-frontend.env
@@ -26,8 +26,8 @@ NEXT_PUBLIC_NETWORK_LOGO_DARK=https://raw.githubusercontent.com/GOATNetwork/goat
 FAVICON_MASTER_URL=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669b090137434ab4c6d11a2_favicoin%20goat.png
 FAVICON_GENERATOR_API_KEY=2VmUPoSqADqZ+3rrsdkZQcR11cZY2uBm
 # network icon
-NEXT_PUBLIC_NETWORK_ICON=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669b090137434ab4c6d11a2_favicoin%20goat.png # backup
-NEXT_PUBLIC_NETWORK_ICON_DARK=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669b090137434ab4c6d11a2_favicoin%20goat.png # backup
+NEXT_PUBLIC_NETWORK_ICON=https://raw.githubusercontent.com/GOATNetwork/goat-docs/main/public/img/icons/favicon.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://raw.githubusercontent.com/GOATNetwork/goat-docs/main/public/img/icons/favicon-dark.png
 # footer links json
 NEXT_PUBLIC_FOOTER_LINKS=https://raw.githubusercontent.com/GOATNetwork/frontend-configs/refs/heads/main/configs/footer-links/goat.json
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=8cba33a48674fdad1f662877990a6764

--- a/docker-compose/envs/common-frontend.env
+++ b/docker-compose/envs/common-frontend.env
@@ -20,8 +20,8 @@ NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.testnet.goat.network
 NEXT_PUBLIC_WEB3_WALLETS=['token_pocket', 'metamask']
 # network logo
-NEXT_PUBLIC_NETWORK_LOGO=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669a5a551ddf74e6fd005e0_goat%20network%20logo.svg
-NEXT_PUBLIC_NETWORK_LOGO_DARK=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669a5a551ddf74e6fd005e0_goat%20network%20logo.svg
+NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/GOATNetwork/goat-docs/main/public/img/GOATlogo/logo-light.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://raw.githubusercontent.com/GOATNetwork/goat-docs/main/public/img/GOATlogo/logo-dark.svg
 # favicon master url
 FAVICON_MASTER_URL=https://cdn.prod.website-files.com/6669a2e2b7f624149423b9be/6669b090137434ab4c6d11a2_favicoin%20goat.png
 FAVICON_GENERATOR_API_KEY=2VmUPoSqADqZ+3rrsdkZQcR11cZY2uBm


### PR DESCRIPTION
## Summary
- Update GOAT explorer frontend env logo URLs to refreshed brand logo assets
- Scope is logo configuration only (top navigation branding)

## Changed file
- docker-compose/envs/common-frontend.env

## Changes
- NEXT_PUBLIC_NETWORK_LOGO -> goat-docs logo-light.svg
- NEXT_PUBLIC_NETWORK_LOGO_DARK -> goat-docs logo-dark.svg

## Safety / scope
- No code logic changes
- No API/data/routing changes
- No content changes
